### PR TITLE
Harden storage handling

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         minSdkVersion 23
         targetSdkVersion 35
 
-        versionCode 44
-        versionName "1.4.4"
+        versionCode 55
+        versionName "1.5"
 
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/com/pocket_plan/j7_003/MainActivity.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/MainActivity.kt
@@ -34,6 +34,7 @@ import com.pocket_plan.j7_003.data.birthdaylist.BirthdayFr
 import com.pocket_plan.j7_003.data.birthdaylist.BirthdayList
 import com.pocket_plan.j7_003.data.fragmenttags.FT
 import com.pocket_plan.j7_003.data.home.HomeFr
+import com.pocket_plan.j7_003.data.notelist.Note
 import com.pocket_plan.j7_003.data.notelist.NoteColors
 import com.pocket_plan.j7_003.data.notelist.NoteDirList
 import com.pocket_plan.j7_003.data.notelist.NoteEditorFr
@@ -416,15 +417,6 @@ class MainActivity : AppCompatActivity() {
 
         if (editNoteContentOnDestroy == null || editNoteTitleOnDestroy == null || noteFr == null || editNoteColorOnDestroy == -1) return
 
-        if (editNoteContentOnDestroy == "" && editNoteTitleOnDestroy == "") {
-            //App was closed when editor window was empty, do nothing
-            getPreferences(Context.MODE_PRIVATE).edit()
-                .putString(PreferenceIDs.EDIT_NOTE_CONTENT.id, "").apply()
-            getPreferences(Context.MODE_PRIVATE).edit()
-                .putString(PreferenceIDs.EDIT_NOTE_TITLE.id, "").apply()
-            return
-        }
-
         //Get saved editNoteContent (this gets written when editor is opened (content of note to edit)
         val editNoteContent =
             getPreferences(Context.MODE_PRIVATE).getString(PreferenceIDs.EDIT_NOTE_CONTENT.id, "")
@@ -432,28 +424,41 @@ class MainActivity : AppCompatActivity() {
             getPreferences(Context.MODE_PRIVATE).getString(PreferenceIDs.EDIT_NOTE_TITLE.id, "")
         val editNoteColor =
             getPreferences(Context.MODE_PRIVATE).getInt(PreferenceIDs.EDIT_NOTE_COLOR.id, -1)
+        val editNoteId =
+            getPreferences(Context.MODE_PRIVATE).getString(PreferenceIDs.EDIT_NOTE_ID.id, "")
+        val editNoteFolderId =
+            getPreferences(Context.MODE_PRIVATE).getString(PreferenceIDs.EDIT_NOTE_FOLDER_ID.id, "")
 
         if (editNoteContent == null || editNoteTitle == null || editNoteColor == -1) return
 
-        resetNotePreferenceStorage()
+        if (editNoteContentOnDestroy == "" && editNoteTitleOnDestroy == "" && editNoteContent == "" && editNoteTitle == "") {
+            //App was closed when a new note editor window was empty, do nothing
+            resetNotePreferenceStorage()
+            return
+        }
 
         if (editNoteContent == "" && editNoteTitle == "") {
             //App was closed after editor was opened for a new note, and app was closed with non-empty editor (see if above)
             //add new note with content of editor saved onDestroy
-            noteFr!!.noteListDirs.rootDir.noteList.addNote(
-                editNoteTitleOnDestroy,
-                editNoteContentOnDestroy, NoteColors.values()[editNoteColorOnDestroy]
+            noteFr!!.noteListDirs.addNoteToFolder(
+                Note(
+                    editNoteTitleOnDestroy,
+                    editNoteContentOnDestroy,
+                    NoteColors.values()[editNoteColorOnDestroy]
+                ),
+                editNoteFolderId
             )
-            noteFr!!.noteListDirs.save()
+            resetNotePreferenceStorage()
             return
         }
 
         if (editNoteContent != editNoteContentOnDestroy || editNoteTitle != editNoteTitleOnDestroy || editNoteColor != editNoteColorOnDestroy) {
             //App was closed, after editor got initialized with text, and this text was modified before the app close, but not saved
-            val editedNote = noteFr!!.noteListDirs.getNoteByTitleAndContent(
+            val editedNote = noteFr!!.noteListDirs.getNoteById(editNoteId) ?: noteFr!!.noteListDirs.getNoteByTitleAndContent(
                 title = editNoteTitle,
                 content = editNoteContent
             ) ?: return
+            resetNotePreferenceStorage()
             NoteFr.editNoteHolder = editedNote
 
             NoteFr.displayContent = editNoteContentOnDestroy
@@ -466,6 +471,8 @@ class MainActivity : AppCompatActivity() {
             changeToFragment(FT.NOTE_EDITOR)
             return
         }
+
+        resetNotePreferenceStorage()
     }
 
     private fun resetNotePreferenceStorage() {
@@ -478,6 +485,10 @@ class MainActivity : AppCompatActivity() {
         getPreferences(Context.MODE_PRIVATE).edit()
             .putString(PreferenceIDs.EDIT_NOTE_TITLE_ON_DESTROY.id, "").apply()
         getPreferences(Context.MODE_PRIVATE).edit().putInt(PreferenceIDs.EDIT_NOTE_COLOR.id, -1)
+            .apply()
+        getPreferences(Context.MODE_PRIVATE).edit().putString(PreferenceIDs.EDIT_NOTE_ID.id, "")
+            .apply()
+        getPreferences(Context.MODE_PRIVATE).edit().putString(PreferenceIDs.EDIT_NOTE_FOLDER_ID.id, "")
             .apply()
         getPreferences(Context.MODE_PRIVATE).edit()
             .putInt(PreferenceIDs.EDIT_NOTE_COLOR_ON_DESTROY.id, -1).apply()
@@ -804,4 +815,3 @@ class MainActivity : AppCompatActivity() {
         myAlertDialog.show()
     }
 }
-

--- a/app/src/main/java/com/pocket_plan/j7_003/PreferenceIDs.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/PreferenceIDs.kt
@@ -4,6 +4,8 @@ enum class PreferenceIDs(val id: String) {
     EDIT_NOTE_CONTENT("editNoteContent"),
     EDIT_NOTE_TITLE("editNoteTitle"),
     EDIT_NOTE_COLOR("editNoteColor"),
+    EDIT_NOTE_ID("editNoteId"),
+    EDIT_NOTE_FOLDER_ID("editNoteFolderId"),
     EDIT_NOTE_CONTENT_ON_DESTROY("editNoteContentOnDestroy"),
     EDIT_NOTE_TITLE_ON_DESTROY("editNoteTitleOnDestroy"),
     EDIT_NOTE_COLOR_ON_DESTROY("editNoteColorOnDestroy")

--- a/app/src/main/java/com/pocket_plan/j7_003/data/birthdaylist/BirthdayList.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/birthdaylist/BirthdayList.kt
@@ -223,9 +223,12 @@ class BirthdayList(private val monthNames: Array<String>) : ArrayList<Birthday>(
             fallbackText = "[]"
         )
 
-        val birthdays = runCatching {
+        val birthdays: ArrayList<Birthday> = runCatching {
             GsonBuilder().create()
-                .fromJson(jsonString, object : TypeToken<ArrayList<Birthday>>() {}.type)
+                .fromJson<ArrayList<Birthday>>(
+                    jsonString,
+                    object : TypeToken<ArrayList<Birthday>>() {}.type
+                )
         }.getOrNull() ?: arrayListOf()
 
         birthdays.forEach {

--- a/app/src/main/java/com/pocket_plan/j7_003/data/birthdaylist/BirthdayList.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/birthdaylist/BirthdayList.kt
@@ -218,12 +218,36 @@ class BirthdayList(private val monthNames: Array<String>) : ArrayList<Birthday>(
     }
 
     private fun fetchFromFile() {
-        val jsonString = StorageHandler.readJsonFromFile(StorageHandler.files[StorageId.BIRTHDAYS])
+        val jsonString = StorageHandler.readJsonFromFile(
+            StorageHandler.files[StorageId.BIRTHDAYS],
+            fallbackText = "[]"
+        )
 
-        this.addAll(
+        val birthdays = runCatching {
             GsonBuilder().create()
                 .fromJson(jsonString, object : TypeToken<ArrayList<Birthday>>() {}.type)
-        )
+        }.getOrNull() ?: arrayListOf()
+
+        birthdays.forEach {
+            runCatching {
+                if (it != null && isStoredBirthdayUsable(it)) this.add(it)
+            }
+        }
+    }
+
+    private fun isStoredBirthdayUsable(birthday: Birthday): Boolean {
+        return runCatching {
+            birthday.name.length
+
+            if (birthday.month !in 1..12 || birthday.day < 0) {
+                false
+            } else {
+                if (birthday.daysToRemind >= 0) {
+                    LocalDate.of(2020, birthday.month, birthday.day)
+                }
+                true
+            }
+        }.getOrDefault(false)
     }
 
     fun save() {

--- a/app/src/main/java/com/pocket_plan/j7_003/data/birthdaylist/BirthdayList.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/birthdaylist/BirthdayList.kt
@@ -218,7 +218,7 @@ class BirthdayList(private val monthNames: Array<String>) : ArrayList<Birthday>(
     }
 
     private fun fetchFromFile() {
-        val jsonString = StorageHandler.files[StorageId.BIRTHDAYS]?.readText()
+        val jsonString = StorageHandler.readJsonFromFile(StorageHandler.files[StorageId.BIRTHDAYS])
 
         this.addAll(
             GsonBuilder().create()

--- a/app/src/main/java/com/pocket_plan/j7_003/data/notelist/Note.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/notelist/Note.kt
@@ -1,6 +1,7 @@
 package com.pocket_plan.j7_003.data.notelist
 
 import com.google.gson.annotations.SerializedName
+import java.util.UUID
 
 data class Note(
     @SerializedName(value = "t")
@@ -13,10 +14,27 @@ data class Note(
     var color: NoteColors,
 
     @SerializedName(value = "nl")
-    var noteList: NoteList
+    var noteList: NoteList,
+
+    @SerializedName(value = "id")
+    var id: String? = UUID.randomUUID().toString()
     ) {
     constructor(name: String, color: NoteColors, noteList: NoteList)
             : this(name, null, color, noteList)
     constructor(name: String, content: String, color: NoteColors)
             : this(name, content, color, NoteList())
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Note) return false
+        return id != null && id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id?.hashCode() ?: System.identityHashCode(this)
+    }
+
+    companion object {
+        fun newId(): String = UUID.randomUUID().toString()
+    }
 }

--- a/app/src/main/java/com/pocket_plan/j7_003/data/notelist/NoteDirList.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/notelist/NoteDirList.kt
@@ -16,6 +16,8 @@ class NoteDirList : Checkable {
     var rootDir: Note = Note(rootDirName, NoteColors.GREEN, NoteList())
     var currentList: () -> NoteList = { folderStack.peek().noteList }
     var folderStack: Stack<Note> = Stack()
+    var loadedFromStorage: Boolean = false
+        private set
 
     init {
         StorageHandler.createJsonFile(StorageId.NOTES)
@@ -24,16 +26,15 @@ class NoteDirList : Checkable {
         } catch (_: Exception) {
             null
         }
-        var loadedFromFile = false
 
         try {   // Todo - part of the compatibility layer; remove try, catch soon
             fetchFromFile(jsonString)
-            loadedFromFile = true
+            loadedFromStorage = true
         } catch (_: Exception) {/* no-op */
         }
         folderStack.push(rootDir)
 
-        if (!loadedFromFile) {
+        if (!loadedFromStorage) {
             try {   // Todo - main part of the comp. layer; also remove soon
                 GsonBuilder().create()
                     .fromJson<LinkedList<Note>>(
@@ -46,13 +47,13 @@ class NoteDirList : Checkable {
                         }
                         currentList().add(it)
                     }
-                loadedFromFile = true
+                loadedFromStorage = true
                 save()
             } catch (_: Exception) {/* no-op */
             }
         }
 
-        if (loadedFromFile && normalizeNotes()) save()
+        if (loadedFromStorage && normalizeNotes()) save()
 
     }
 

--- a/app/src/main/java/com/pocket_plan/j7_003/data/notelist/NoteDirList.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/notelist/NoteDirList.kt
@@ -42,6 +42,8 @@ class NoteDirList : Checkable {
         } catch (_: Exception) {/* no-op */
         }
 
+        if (normalizeNotes()) save()
+
     }
 
     /**
@@ -57,7 +59,12 @@ class NoteDirList : Checkable {
     }
 
     fun remove(note: Note) {
-        currentList().remove(note)
+        val parentDirectory = getParentDirectoryOrNull(note)
+        if (parentDirectory != null) {
+            parentDirectory.noteList.remove(note)
+        } else {
+            currentList().remove(note)
+        }
         save()
     }
 
@@ -88,7 +95,11 @@ class NoteDirList : Checkable {
     }
 
     fun getParentDirectory(dir: Note): Note {
-        return getDirPathsWithRef().find { it.second.noteList.contains(dir) }!!.second
+        return getParentDirectoryOrNull(dir)!!
+    }
+
+    private fun getParentDirectoryOrNull(dir: Note): Note? {
+        return getDirPathsWithRef().find { it.second.noteList.contains(dir) }?.second
     }
 
     fun moveDir(noteToMove: Note, toIndex: Int): Boolean {
@@ -143,6 +154,22 @@ class NoteDirList : Checkable {
             } else {
                 //Check subDirectory val
                 val subResult = getNoteByTitleAndContent(title, content, note)
+                if (subResult != null) return subResult
+            }
+        }
+        return null
+    }
+
+    fun getNoteById(id: String?, directory: Note = rootDir): Note? {
+        if (id.isNullOrBlank()) return null
+        if (directory.id == id) return directory
+
+        for (note in directory.noteList) {
+            if (note.id == id) {
+                return note
+            }
+            if (note.content == null) {
+                val subResult = getNoteById(id, note)
                 if (subResult != null) return subResult
             }
         }
@@ -255,6 +282,8 @@ class NoteDirList : Checkable {
         folderStack.push(rootDir)
     }
 
+    fun getCurrentFolderId(): String? = folderStack.peek().id
+
     /**
      * Deletes the currently opened folder, except for the root folder which can't
      * be deleted. Also saves the notes to file.
@@ -288,18 +317,28 @@ class NoteDirList : Checkable {
      * @see NoteList.addNote
      */
     fun addNote(note: Note) {
+        addNoteToList(currentList(), note)
+        save()
+    }
+
+    fun addNoteToFolder(note: Note, folderId: String?) {
+        val folder = getNoteById(folderId)?.takeIf { it.content == null } ?: rootDir
+        addNoteToList(folder.noteList, note)
+        save()
+    }
+
+    private fun addNoteToList(noteList: NoteList, note: Note) {
         if (SettingsManager.getSetting(SettingId.NOTES_MOVE_UP_CURRENT) as Boolean) {
             var index = 0
-            for (n in currentList()){
-                if (n.content == null){
+            for (n in noteList) {
+                if (n.content == null) {
                     index += 1
                 }
             }
-            currentList().add(index, note)
+            noteList.add(index, note)
         } else {
-            currentList().add(note)
+            noteList.add(note)
         }
-        save()
     }
 
     /**
@@ -344,8 +383,10 @@ class NoteDirList : Checkable {
         val jsonString = StorageHandler.files[StorageId.NOTES]?.readText()
 
         rootDir = GsonBuilder().create().fromJson(jsonString, object : TypeToken<Note>() {}.type)
+        val normalized = normalizeNotes()
 
         if (SettingsManager.getSetting(SettingId.NOTES_DIRS_TO_TOP) as Boolean) sortDirsToTop()
+        if (normalized) save()
     }
 
     fun sortDirsToTop() {
@@ -375,5 +416,35 @@ class NoteDirList : Checkable {
         }
 
         return results
+    }
+
+    private fun normalizeNotes(): Boolean {
+        val usedIds = HashSet<String>()
+
+        fun normalize(note: Note): Boolean {
+            var changed = false
+            val noteId = note.id
+
+            if (noteId.isNullOrBlank() || !usedIds.add(noteId)) {
+                var newId: String
+                do {
+                    newId = Note.newId()
+                } while (!usedIds.add(newId))
+                note.id = newId
+                changed = true
+            }
+
+            if (note.noteList == null) {
+                note.noteList = NoteList()
+                changed = true
+            }
+
+            note.noteList.forEach {
+                if (normalize(it)) changed = true
+            }
+            return changed
+        }
+
+        return normalize(rootDir)
     }
 }

--- a/app/src/main/java/com/pocket_plan/j7_003/data/notelist/NoteDirList.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/notelist/NoteDirList.kt
@@ -19,30 +19,40 @@ class NoteDirList : Checkable {
 
     init {
         StorageHandler.createJsonFile(StorageId.NOTES)
+        val jsonString = try {
+            StorageHandler.readJsonFromFile(StorageHandler.files[StorageId.NOTES])
+        } catch (_: Exception) {
+            null
+        }
+        var loadedFromFile = false
+
         try {   // Todo - part of the compatibility layer; remove try, catch soon
-            fetchFromFile()
+            fetchFromFile(jsonString)
+            loadedFromFile = true
         } catch (_: Exception) {/* no-op */
         }
         folderStack.push(rootDir)
 
-        try {   // Todo - main part of the comp. layer; also remove soon
-            val jsonString = StorageHandler.files[StorageId.NOTES]?.readText()
-            GsonBuilder().create()
-                .fromJson<LinkedList<Note>>(
-                    jsonString,
-                    object : TypeToken<LinkedList<Note>>() {}.type
-                )
-                .forEach {
-                    if (it.noteList == null) {
-                        it.noteList = NoteList()
+        if (!loadedFromFile) {
+            try {   // Todo - main part of the comp. layer; also remove soon
+                GsonBuilder().create()
+                    .fromJson<LinkedList<Note>>(
+                        jsonString,
+                        object : TypeToken<LinkedList<Note>>() {}.type
+                    )
+                    .forEach {
+                        if (it.noteList == null) {
+                            it.noteList = NoteList()
+                        }
+                        currentList().add(it)
                     }
-                    currentList().add(it)
-                }
-            save()
-        } catch (_: Exception) {/* no-op */
+                loadedFromFile = true
+                save()
+            } catch (_: Exception) {/* no-op */
+            }
         }
 
-        if (normalizeNotes()) save()
+        if (loadedFromFile && normalizeNotes()) save()
 
     }
 
@@ -379,10 +389,10 @@ class NoteDirList : Checkable {
         )
     }
 
-    private fun fetchFromFile() {
-        val jsonString = StorageHandler.files[StorageId.NOTES]?.readText()
-
+    private fun fetchFromFile(jsonString: String?) {
+        if (jsonString == null) throw IllegalStateException("Missing notes JSON")
         rootDir = GsonBuilder().create().fromJson(jsonString, object : TypeToken<Note>() {}.type)
+            ?: throw IllegalStateException("Missing notes root")
         val normalized = normalizeNotes()
 
         if (SettingsManager.getSetting(SettingId.NOTES_DIRS_TO_TOP) as Boolean) sortDirsToTop()

--- a/app/src/main/java/com/pocket_plan/j7_003/data/notelist/NoteEditorFr.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/notelist/NoteEditorFr.kt
@@ -99,6 +99,13 @@ class NoteEditorFr : Fragment() {
                 PreferenceIDs.EDIT_NOTE_COLOR.id,
                 NoteColors.entries.indexOf(NoteFr.editNoteHolder!!.color)
             ).apply()
+            myActivity.getPreferences(Context.MODE_PRIVATE).edit()
+                .putString(PreferenceIDs.EDIT_NOTE_ID.id, NoteFr.editNoteHolder!!.id ?: "")
+                .apply()
+            myActivity.getPreferences(Context.MODE_PRIVATE).edit().putString(
+                PreferenceIDs.EDIT_NOTE_FOLDER_ID.id,
+                myNoteFr.noteListDirs.getParentDirectory(NoteFr.editNoteHolder!!).id ?: ""
+            ).apply()
             fragmentBinding.etNoteTitle.clearFocus()
         } else {
             //Empty editNoteContent to signal we are adding a new note
@@ -112,6 +119,12 @@ class NoteEditorFr : Fragment() {
                 PreferenceIDs.EDIT_NOTE_COLOR.id, NoteColors.entries.indexOf(
                     noteColor
                 )
+            ).apply()
+            myActivity.getPreferences(Context.MODE_PRIVATE).edit()
+                .putString(PreferenceIDs.EDIT_NOTE_ID.id, "").apply()
+            myActivity.getPreferences(Context.MODE_PRIVATE).edit().putString(
+                PreferenceIDs.EDIT_NOTE_FOLDER_ID.id,
+                myNoteFr.noteListDirs.getCurrentFolderId() ?: ""
             ).apply()
             fragmentBinding.etNoteContent.requestFocus()
             fragmentBinding.etNoteContent.postDelayed({

--- a/app/src/main/java/com/pocket_plan/j7_003/data/notelist/NoteList.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/notelist/NoteList.kt
@@ -19,7 +19,7 @@ class NoteList : LinkedList<Note>(), Checkable {
      * Small helper function to add a note object, used for undoing deletions
      */
     fun addFullNote(note: Note): Int {
-        addNote(note.title, note.content!!, note.color)
+        this.push(note)
         return this.indexOf(note)
     }
 

--- a/app/src/main/java/com/pocket_plan/j7_003/data/settings/SettingsManager.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/settings/SettingsManager.kt
@@ -15,7 +15,7 @@ class SettingsManager {
             try {
                 load()
             } catch (_: Exception) {
-                StorageHandler.files[StorageId.SETTINGS]?.writeText("[]")
+                StorageHandler.writeTextToFile(StorageHandler.files[StorageId.SETTINGS], "[]")
             }
         }
 
@@ -42,7 +42,7 @@ class SettingsManager {
         }
 
         private fun load() {
-            val jsonString = StorageHandler.files[StorageId.SETTINGS]?.readText()
+            val jsonString = StorageHandler.readJsonFromFile(StorageHandler.files[StorageId.SETTINGS])
 
             val cacheMap: HashMap<String, Any> = GsonBuilder().create()
                 .fromJson(jsonString, object : TypeToken<HashMap<String, Any>>() {}.type)

--- a/app/src/main/java/com/pocket_plan/j7_003/data/settings/SettingsManager.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/settings/SettingsManager.kt
@@ -15,7 +15,7 @@ class SettingsManager {
             try {
                 load()
             } catch (_: Exception) {
-                StorageHandler.writeTextToFile(StorageHandler.files[StorageId.SETTINGS], "[]")
+                StorageHandler.writeTextToFile(StorageHandler.files[StorageId.SETTINGS], "{}")
             }
         }
 
@@ -42,7 +42,10 @@ class SettingsManager {
         }
 
         private fun load() {
-            val jsonString = StorageHandler.readJsonFromFile(StorageHandler.files[StorageId.SETTINGS])
+            val jsonString = StorageHandler.readJsonFromFile(
+                StorageHandler.files[StorageId.SETTINGS],
+                fallbackText = "{}"
+            )
 
             val cacheMap: HashMap<String, Any> = GsonBuilder().create()
                 .fromJson(jsonString, object : TypeToken<HashMap<String, Any>>() {}.type)
@@ -56,7 +59,7 @@ class SettingsManager {
         }
 
         private fun createFile() {
-            StorageHandler.createJsonFile(StorageId.SETTINGS)
+            StorageHandler.createJsonFile(StorageId.SETTINGS, text = "{}")
         }
 
         override fun check() {

--- a/app/src/main/java/com/pocket_plan/j7_003/data/settings/sub_categories/shoppinglist/CustomItemFr.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/settings/sub_categories/shoppinglist/CustomItemFr.kt
@@ -19,6 +19,7 @@ import com.pocket_plan.j7_003.data.settings.SettingId
 import com.pocket_plan.j7_003.data.settings.SettingsManager
 import com.pocket_plan.j7_003.data.shoppinglist.ItemTemplate
 import com.pocket_plan.j7_003.data.shoppinglist.MultiShoppingFr
+import com.pocket_plan.j7_003.data.shoppinglist.ShoppingCategories
 import com.pocket_plan.j7_003.databinding.FragmentCustomItemsBinding
 import com.pocket_plan.j7_003.databinding.RowCustomItemBinding
 
@@ -198,8 +199,7 @@ class CustomItemAdapter(val myActivity: MainActivity) :
         holder.binding.tvName.text = currentItem.n
 
         //show category
-        val id = myActivity.resources.getStringArray(R.array.categoryCodes).indexOf(currentItem.c)
-        val catText = myActivity.resources.getStringArray(R.array.categoryNames)[id]
+        val catText = ShoppingCategories.nameForTag(myActivity.resources, currentItem.c)
         holder.binding.tvCategory.text =
             myActivity.getString(R.string.settingsCustomCategory) + ":  " + catText
 

--- a/app/src/main/java/com/pocket_plan/j7_003/data/shoppinglist/MultiShoppingFr.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/shoppinglist/MultiShoppingFr.kt
@@ -556,8 +556,8 @@ class MultiShoppingFr : Fragment() {
                 if (template != null) {
                     unitToSet =
                         myActivity.resources.getStringArray(R.array.units).indexOf(template.s)
-                    categoryToSet = myActivity.resources.getStringArray(R.array.categoryCodes)
-                        .indexOf(template.c)
+                    if (unitToSet == -1) unitToSet = 0
+                    categoryToSet = ShoppingCategories.indexForTag(myActivity.resources, template.c)
                 }
 
                 //Apply selections
@@ -627,9 +627,7 @@ class MultiShoppingFr : Fragment() {
 
             //get selected categoryCode
             val categoryCode =
-                myActivity.resources.getStringArray(R.array.categoryCodes)[myActivity.resources.getStringArray(
-                    R.array.categoryNames
-                ).indexOf(spCategory.selectedItem as String)]
+                ShoppingCategories.codeForName(myActivity.resources, spCategory.selectedItem as String)
 
             //check if user template exists for this string
             var template =
@@ -775,6 +773,7 @@ class MultiShoppingFr : Fragment() {
         val unitIndex = myActivity.resources
             .getStringArray(R.array.units)
             .indexOf(item.suggestedUnit)
+            .takeIf { it != -1 } ?: 0
 
         dialogAddItemBinding.spItemUnit.tag = unitIndex
         //Select correct unit when opening dialog for edit

--- a/app/src/main/java/com/pocket_plan/j7_003/data/shoppinglist/ShoppingCategories.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/shoppinglist/ShoppingCategories.kt
@@ -1,0 +1,45 @@
+package com.pocket_plan.j7_003.data.shoppinglist
+
+import android.content.res.Resources
+import com.pocket_plan.j7_003.R
+
+object ShoppingCategories {
+    const val DEFAULT_TAG = "So"
+
+    private val validTags = setOf(
+        "So", "Ob", "Gt", "Nu", "Bw", "Km", "Kf", "Ve", "Tk",
+        "Ko", "Fr", "Gw", "Ha", "Sn", "Bz", "Dr", "Al"
+    )
+
+    fun normalizeTag(tag: String?): String {
+        return if (tag != null && validTags.contains(tag)) tag else DEFAULT_TAG
+    }
+
+    fun indexForTag(resources: Resources, tag: String?): Int {
+        val codes = resources.getStringArray(R.array.categoryCodes)
+        val index = codes.indexOf(normalizeTag(tag))
+        return when (index in codes.indices) {
+            true -> index
+            false -> 0
+        }
+    }
+
+    fun nameForTag(resources: Resources, tag: String): String {
+        val names = resources.getStringArray(R.array.categoryNames)
+        val index = indexForTag(resources, tag)
+        return when (index in names.indices) {
+            true -> names[index]
+            false -> names[0]
+        }
+    }
+
+    fun codeForName(resources: Resources, name: String?): String {
+        val names = resources.getStringArray(R.array.categoryNames)
+        val codes = resources.getStringArray(R.array.categoryCodes)
+        val index = names.indexOf(name)
+        return when (index in codes.indices) {
+            true -> codes[index]
+            false -> DEFAULT_TAG
+        }
+    }
+}

--- a/app/src/main/java/com/pocket_plan/j7_003/data/shoppinglist/ShoppingFr.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/shoppinglist/ShoppingFr.kt
@@ -63,9 +63,7 @@ class ShoppingFr : Fragment() {
     fun getCategoryVisibility(category: Pair<String, ArrayList<ShoppingItem>>): Boolean {
 
         val categoryName =
-            myActivity.resources.getStringArray(R.array.categoryNames)[myActivity.resources.getStringArray(
-                R.array.categoryCodes
-            ).indexOf(category.first)]
+            ShoppingCategories.nameForTag(myActivity.resources, category.first)
         if (categoryName.lowercase(Locale.ROOT).contains(query!!.lowercase(Locale.ROOT))) {
             return true
         }
@@ -83,9 +81,7 @@ class ShoppingFr : Fragment() {
 
     fun getItemVisibility(item: ShoppingItem): Boolean {
         val categoryName =
-            myActivity.resources.getStringArray(R.array.categoryNames)[myActivity.resources.getStringArray(
-                R.array.categoryCodes
-            ).indexOf(item.tag)]
+            ShoppingCategories.nameForTag(myActivity.resources, item.tag)
         if (categoryName.lowercase().contains(query!!.lowercase())) {
             return true
         }
@@ -366,9 +362,7 @@ class ShoppingListAdapter(mainActivity: MainActivity, shoppingFr: ShoppingFr) :
 
         //Sets Text name of category of sublist
         holder.binding.tvCategoryName.text =
-            myActivity.resources.getStringArray(R.array.categoryNames)[myActivity.resources.getStringArray(
-                R.array.categoryCodes
-            ).indexOf(tag)]
+            ShoppingCategories.nameForTag(myActivity.resources, tag)
 
         //Sets background color of sublist according to the tag
         manageCheckedCategory(
@@ -847,4 +841,3 @@ class SwipeItemToDelete(direction: Int, shoppingFr: ShoppingFr) :
 
     }
 }
-

--- a/app/src/main/java/com/pocket_plan/j7_003/data/shoppinglist/ShoppingList.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/shoppinglist/ShoppingList.kt
@@ -16,27 +16,33 @@ class ShoppingList(private var wrapper: ShoppingListWrapper?) :
         val normalizedLists = LinkedHashMap<String, ArrayList<ShoppingItem>>()
         var changed = false
 
-        this.forEach { (tag, items) ->
-            val normalizedTag = ShoppingCategories.normalizeTag(tag)
-            if (normalizedTag != tag) changed = true
+        this.forEach { category ->
+            runCatching {
+                val tag = category.first
+                val items = category.second
+                val normalizedTag = ShoppingCategories.normalizeTag(tag)
+                if (normalizedTag != tag) changed = true
 
-            if (items.isEmpty()) {
-                items.add(ShoppingItem(normalizedTag, checked = false, position = "0"))
-                changed = true
-            }
-
-            items.forEach {
-                if (it.tag != normalizedTag) {
-                    it.tag = normalizedTag
+                if (items.isEmpty()) {
+                    items.add(ShoppingItem(normalizedTag, checked = false, position = "0"))
                     changed = true
                 }
-            }
 
-            val existingItems = normalizedLists[normalizedTag]
-            if (existingItems == null) {
-                normalizedLists[normalizedTag] = items
-            } else {
-                existingItems.addAll(items.drop(1))
+                items.forEach {
+                    if (it.tag != normalizedTag) {
+                        it.tag = normalizedTag
+                        changed = true
+                    }
+                }
+
+                val existingItems = normalizedLists[normalizedTag]
+                if (existingItems == null) {
+                    normalizedLists[normalizedTag] = items
+                } else {
+                    existingItems.addAll(items.drop(1))
+                    changed = true
+                }
+            }.onFailure {
                 changed = true
             }
         }

--- a/app/src/main/java/com/pocket_plan/j7_003/data/shoppinglist/ShoppingList.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/shoppinglist/ShoppingList.kt
@@ -11,6 +11,48 @@ class ShoppingList(private var wrapper: ShoppingListWrapper?) :
     fun setWrapper(newWrapper: ShoppingListWrapper) {
         this.wrapper = newWrapper
     }
+
+    fun normalizeCategoryTags(): Boolean {
+        val normalizedLists = LinkedHashMap<String, ArrayList<ShoppingItem>>()
+        var changed = false
+
+        this.forEach { (tag, items) ->
+            val normalizedTag = ShoppingCategories.normalizeTag(tag)
+            if (normalizedTag != tag) changed = true
+
+            if (items.isEmpty()) {
+                items.add(ShoppingItem(normalizedTag, checked = false, position = "0"))
+                changed = true
+            }
+
+            items.forEach {
+                if (it.tag != normalizedTag) {
+                    it.tag = normalizedTag
+                    changed = true
+                }
+            }
+
+            val existingItems = normalizedLists[normalizedTag]
+            if (existingItems == null) {
+                normalizedLists[normalizedTag] = items
+            } else {
+                existingItems.addAll(items.drop(1))
+                changed = true
+            }
+        }
+
+        if (changed) {
+            clear()
+            normalizedLists.forEach { (tag, items) ->
+                sortSublist(items)
+                add(Pair(tag, items))
+            }
+            updateOrder()
+        }
+
+        return changed
+    }
+
     /**
      * Adds a given ShoppingElement to this list, according to its given tag.
      * If no element of the given tag existed before, the list generate a new sublist,
@@ -19,6 +61,8 @@ class ShoppingList(private var wrapper: ShoppingListWrapper?) :
      * @param element The element to be added to the list.
      */
     fun add(element: ShoppingItem) {
+        element.tag = ShoppingCategories.normalizeTag(element.tag)
+
         this.forEach { e ->         // searching for preexistence of the elements tag
             if (e.first == element.tag) {   // add element to tags sublist and save to file
                 e.second.add(element)

--- a/app/src/main/java/com/pocket_plan/j7_003/data/shoppinglist/ShoppingListWrapper.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/shoppinglist/ShoppingListWrapper.kt
@@ -22,6 +22,7 @@ class ShoppingListWrapper(defaultListName: String = ""): ArrayList<Pair<String, 
         // TODO - this is the compatibility layer for saving
         //  category order remove after a few releases
         this.forEach { (_, list) ->
+            list.normalizeCategoryTags()
             list.forEach {
                 if (it.second[0].amount == null)
                     it.second[0].amount = list.indexOf(it).toString()

--- a/app/src/main/java/com/pocket_plan/j7_003/data/shoppinglist/ShoppingListWrapper.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/shoppinglist/ShoppingListWrapper.kt
@@ -22,10 +22,12 @@ class ShoppingListWrapper(defaultListName: String = ""): ArrayList<Pair<String, 
         // TODO - this is the compatibility layer for saving
         //  category order remove after a few releases
         this.forEach { (_, list) ->
-            list.normalizeCategoryTags()
-            list.forEach {
-                if (it.second[0].amount == null)
-                    it.second[0].amount = list.indexOf(it).toString()
+            runCatching {
+                list.normalizeCategoryTags()
+                list.forEach {
+                    if (it.second[0].amount == null)
+                        it.second[0].amount = list.indexOf(it).toString()
+                }
             }
         }
         save()
@@ -128,20 +130,35 @@ class ShoppingListWrapper(defaultListName: String = ""): ArrayList<Pair<String, 
     }
 
     private fun fetchList() {
-        val jsonString = StorageHandler.readJsonFromFile(StorageHandler.files[StorageId.SHOPPING_LISTS])
-        val list: ArrayList<Pair<String, ShoppingList>> = GsonBuilder().create().fromJson(
+        if (this.isNotEmpty()) return
+
+        val jsonString = StorageHandler.readJsonFromFile(
+            StorageHandler.files[StorageId.SHOPPING_LISTS],
+            fallbackText = "[]"
+        )
+        val list: ArrayList<Pair<String, ShoppingList>> = runCatching {
+            GsonBuilder().create().fromJson(
                 jsonString,
                 object : TypeToken<ArrayList<Pair<String, ShoppingList>>>() {}.type
             )
-        list.forEach{
-            it.second.setWrapper(this)
+        }.getOrNull() ?: arrayListOf()
+        list.forEach {
+            runCatching {
+                val name = it.first.trim()
+                if (name.isNotEmpty()) {
+                    it.second.setWrapper(this)
+                    this.add(Pair(name, it.second))
+                }
+            }
         }
-        this.addAll(list)
     }
 
     private fun accountCompatibility() {    // TODO - remove when enough users updated
         StorageHandler.createJsonFile(StorageId.SHOPPING)
-        val jsonString = StorageHandler.readJsonFromFile(StorageHandler.files[StorageId.SHOPPING])
+        val jsonString = StorageHandler.readJsonFromFile(
+            StorageHandler.files[StorageId.SHOPPING],
+            fallbackText = "[]"
+        )
 
         if (jsonString == "[]") {
             StorageHandler.files[StorageId.SHOPPING]?.delete()
@@ -149,14 +166,18 @@ class ShoppingListWrapper(defaultListName: String = ""): ArrayList<Pair<String, 
             return
         }
 
-        val list: ArrayList<Pair<String, ArrayList<ShoppingItem>>> = GsonBuilder().create().fromJson(
-            jsonString,
-            object : TypeToken<ArrayList<Pair<String, ArrayList<ShoppingItem>>>>() {}.type
-        )
+        val list: ArrayList<Pair<String, ArrayList<ShoppingItem>>> = runCatching {
+            GsonBuilder().create().fromJson(
+                jsonString,
+                object : TypeToken<ArrayList<Pair<String, ArrayList<ShoppingItem>>>>() {}.type
+            )
+        }.getOrNull() ?: arrayListOf()
 
         val shoppingList = ShoppingList(this)
         list.forEach {
-            shoppingList.add(it)
+            runCatching {
+                shoppingList.add(it)
+            }
         }
 
         this.add(defaultName, shoppingList)

--- a/app/src/main/java/com/pocket_plan/j7_003/data/shoppinglist/ShoppingListWrapper.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/shoppinglist/ShoppingListWrapper.kt
@@ -127,7 +127,7 @@ class ShoppingListWrapper(defaultListName: String = ""): ArrayList<Pair<String, 
     }
 
     private fun fetchList() {
-        val jsonString = StorageHandler.files[StorageId.SHOPPING_LISTS]?.readText()
+        val jsonString = StorageHandler.readJsonFromFile(StorageHandler.files[StorageId.SHOPPING_LISTS])
         val list: ArrayList<Pair<String, ShoppingList>> = GsonBuilder().create().fromJson(
                 jsonString,
                 object : TypeToken<ArrayList<Pair<String, ShoppingList>>>() {}.type
@@ -140,7 +140,7 @@ class ShoppingListWrapper(defaultListName: String = ""): ArrayList<Pair<String, 
 
     private fun accountCompatibility() {    // TODO - remove when enough users updated
         StorageHandler.createJsonFile(StorageId.SHOPPING)
-        val jsonString = StorageHandler.files[StorageId.SHOPPING]?.readText()
+        val jsonString = StorageHandler.readJsonFromFile(StorageHandler.files[StorageId.SHOPPING])
 
         if (jsonString == "[]") {
             StorageHandler.files[StorageId.SHOPPING]?.delete()

--- a/app/src/main/java/com/pocket_plan/j7_003/data/shoppinglist/ShoppingListWrapper.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/shoppinglist/ShoppingListWrapper.kt
@@ -137,7 +137,7 @@ class ShoppingListWrapper(defaultListName: String = ""): ArrayList<Pair<String, 
             fallbackText = "[]"
         )
         val list: ArrayList<Pair<String, ShoppingList>> = runCatching {
-            GsonBuilder().create().fromJson(
+            GsonBuilder().create().fromJson<ArrayList<Pair<String, ShoppingList>>>(
                 jsonString,
                 object : TypeToken<ArrayList<Pair<String, ShoppingList>>>() {}.type
             )
@@ -167,7 +167,7 @@ class ShoppingListWrapper(defaultListName: String = ""): ArrayList<Pair<String, 
         }
 
         val list: ArrayList<Pair<String, ArrayList<ShoppingItem>>> = runCatching {
-            GsonBuilder().create().fromJson(
+            GsonBuilder().create().fromJson<ArrayList<Pair<String, ArrayList<ShoppingItem>>>>(
                 jsonString,
                 object : TypeToken<ArrayList<Pair<String, ArrayList<ShoppingItem>>>>() {}.type
             )

--- a/app/src/main/java/com/pocket_plan/j7_003/data/shoppinglist/UserItemTemplateList.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/shoppinglist/UserItemTemplateList.kt
@@ -64,18 +64,28 @@ class UserItemTemplateList: ArrayList<ItemTemplate>(), Checkable {
 
     private fun fetchList() {
         val list = ArrayList<TMPTemplate>()
-        val jsonString = StorageHandler.readJsonFromFile(StorageHandler.files[StorageId.USER_TEMPLATE_LIST])
+        val jsonString = StorageHandler.readJsonFromFile(
+            StorageHandler.files[StorageId.USER_TEMPLATE_LIST],
+            fallbackText = "[]"
+        )
 
-        list.addAll(
+        val savedTemplates = runCatching {
             GsonBuilder().create()
             .fromJson(jsonString,
-                object : TypeToken<ArrayList<TMPTemplate>>() {}.type))
+                object : TypeToken<ArrayList<TMPTemplate>>() {}.type)
+        }.getOrNull() ?: arrayListOf()
+
+        list.addAll(savedTemplates)
 
         var changed = false
         list.forEach { e ->
-            val normalizedCategory = ShoppingCategories.normalizeTag(e.c)
-            if (normalizedCategory != e.c) changed = true
-            super.add(ItemTemplate(e.n, normalizedCategory, e.s))
+            runCatching {
+                e.n.length
+                e.s.length
+                val normalizedCategory = ShoppingCategories.normalizeTag(e.c)
+                if (normalizedCategory != e.c) changed = true
+                super.add(ItemTemplate(e.n, normalizedCategory, e.s))
+            }
         }
         if (changed) save()
     }

--- a/app/src/main/java/com/pocket_plan/j7_003/data/shoppinglist/UserItemTemplateList.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/shoppinglist/UserItemTemplateList.kt
@@ -64,7 +64,7 @@ class UserItemTemplateList: ArrayList<ItemTemplate>(), Checkable {
 
     private fun fetchList() {
         val list = ArrayList<TMPTemplate>()
-        val jsonString = StorageHandler.files[StorageId.USER_TEMPLATE_LIST]?.readText()
+        val jsonString = StorageHandler.readJsonFromFile(StorageHandler.files[StorageId.USER_TEMPLATE_LIST])
 
         list.addAll(
             GsonBuilder().create()

--- a/app/src/main/java/com/pocket_plan/j7_003/data/shoppinglist/UserItemTemplateList.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/shoppinglist/UserItemTemplateList.kt
@@ -71,9 +71,13 @@ class UserItemTemplateList: ArrayList<ItemTemplate>(), Checkable {
             .fromJson(jsonString,
                 object : TypeToken<ArrayList<TMPTemplate>>() {}.type))
 
+        var changed = false
         list.forEach { e ->
-            this.add(ItemTemplate(e.n, e.c, e.s))
+            val normalizedCategory = ShoppingCategories.normalizeTag(e.c)
+            if (normalizedCategory != e.c) changed = true
+            super.add(ItemTemplate(e.n, normalizedCategory, e.s))
         }
+        if (changed) save()
     }
 
     private class TMPTemplate(val n: String, val c: String, val s: String)

--- a/app/src/main/java/com/pocket_plan/j7_003/data/shoppinglist/UserItemTemplateList.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/shoppinglist/UserItemTemplateList.kt
@@ -69,10 +69,12 @@ class UserItemTemplateList: ArrayList<ItemTemplate>(), Checkable {
             fallbackText = "[]"
         )
 
-        val savedTemplates = runCatching {
+        val savedTemplates: ArrayList<TMPTemplate> = runCatching {
             GsonBuilder().create()
-            .fromJson(jsonString,
-                object : TypeToken<ArrayList<TMPTemplate>>() {}.type)
+            .fromJson<ArrayList<TMPTemplate>>(
+                jsonString,
+                object : TypeToken<ArrayList<TMPTemplate>>() {}.type
+            )
         }.getOrNull() ?: arrayListOf()
 
         list.addAll(savedTemplates)

--- a/app/src/main/java/com/pocket_plan/j7_003/data/sleepreminder/SleepReminder.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/sleepreminder/SleepReminder.kt
@@ -128,7 +128,7 @@ class SleepReminder(passedContext: Context) : Checkable {
 
     private fun load() {
         val file = StorageHandler.files[StorageId.SLEEP]
-        val raw = StorageHandler.readJsonFromFile(file)?.trim()
+        val raw = StorageHandler.readJsonFromFile(file, fallbackText = Gson().toJson(reminder))?.trim()
         val gson: Gson = GsonBuilder().create()
         val mapType = object : TypeToken<HashMap<DayOfWeek, Reminder>>() {}.type
 

--- a/app/src/main/java/com/pocket_plan/j7_003/data/sleepreminder/SleepReminder.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/sleepreminder/SleepReminder.kt
@@ -167,11 +167,46 @@ class SleepReminder(passedContext: Context) : Checkable {
             freshDefaults()
         }
 
+        reminder = sanitizeReminderMap(reminder)
         daysAreCustom = (SettingsManager.getSetting(SettingId.DAYS_ARE_CUSTOM) as? Boolean) ?: false
 
         reminder.forEach { entry -> entry.value.mySleepReminder = this }
 
         updateReminder()
+    }
+
+    private fun sanitizeReminderMap(loadedReminder: HashMap<DayOfWeek, Reminder>): HashMap<DayOfWeek, Reminder> {
+        val sanitized = HashMap<DayOfWeek, Reminder>(7)
+        var changed = loadedReminder.size != DayOfWeek.values().size
+
+        DayOfWeek.values().forEach { day ->
+            val reminderForDay = loadedReminder[day]
+            if (reminderForDay != null && reminderForDay.isUsable(day)) {
+                reminderForDay.mySleepReminder = this
+                sanitized[day] = reminderForDay
+            } else {
+                sanitized[day] = Reminder(day, this)
+                changed = true
+            }
+        }
+
+        if (changed) {
+            StorageHandler.saveAsJsonToFile(StorageHandler.files[StorageId.SLEEP], sanitized)
+            Log.w(TAG, "Repaired SLEEP JSON with missing or invalid reminders")
+        }
+
+        return sanitized
+    }
+
+    private fun Reminder.isUsable(day: DayOfWeek): Boolean {
+        return runCatching {
+            val reminderDuration = duration.toMinutes()
+            nextReminder.toLocalDate()
+            weekday == day &&
+                    wakeUpTime.hour in 0..23 &&
+                    wakeUpTime.minute in 0..59 &&
+                    reminderDuration in 0L until (24L * 60L)
+        }.getOrDefault(false)
     }
 
     private fun getNextTwoReminder(): Pair<Reminder, Reminder> {
@@ -241,7 +276,7 @@ class SleepReminder(passedContext: Context) : Checkable {
      */
     inner class Reminder(
         @SerializedName(value = "w")
-        private val weekday: DayOfWeek,
+        val weekday: DayOfWeek,
         @Transient
         var mySleepReminder: SleepReminder
     ) {

--- a/app/src/main/java/com/pocket_plan/j7_003/data/sleepreminder/SleepReminder.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/sleepreminder/SleepReminder.kt
@@ -128,7 +128,7 @@ class SleepReminder(passedContext: Context) : Checkable {
 
     private fun load() {
         val file = StorageHandler.files[StorageId.SLEEP]
-        val raw = file?.takeIf { it.exists() }?.readText()?.trim()
+        val raw = StorageHandler.readJsonFromFile(file)?.trim()
         val gson: Gson = GsonBuilder().create()
         val mapType = object : TypeToken<HashMap<DayOfWeek, Reminder>>() {}.type
 

--- a/app/src/main/java/com/pocket_plan/j7_003/data/todolist/TodoList.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/todolist/TodoList.kt
@@ -108,9 +108,11 @@ class TodoList: ArrayList<Task>(), Checkable{
             fallbackText = "[]"
         )
 
-        val tasks = runCatching {
-            GsonBuilder().create().fromJson(
-                jsonString, object : TypeToken<ArrayList<Task>>() {}.type)
+        val tasks: ArrayList<Task> = runCatching {
+            GsonBuilder().create().fromJson<ArrayList<Task>>(
+                jsonString,
+                object : TypeToken<ArrayList<Task>>() {}.type
+            )
         }.getOrNull() ?: arrayListOf()
 
         tasks.forEach {

--- a/app/src/main/java/com/pocket_plan/j7_003/data/todolist/TodoList.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/todolist/TodoList.kt
@@ -103,11 +103,28 @@ class TodoList: ArrayList<Task>(), Checkable{
     }
 
     private fun fetchFromFile() {
-        val jsonString = StorageHandler.readJsonFromFile(StorageHandler.files[StorageId.TASKS])
+        val jsonString = StorageHandler.readJsonFromFile(
+            StorageHandler.files[StorageId.TASKS],
+            fallbackText = "[]"
+        )
 
-        this.addAll(
+        val tasks = runCatching {
             GsonBuilder().create().fromJson(
-                jsonString, object : TypeToken<ArrayList<Task>>() {}.type))
+                jsonString, object : TypeToken<ArrayList<Task>>() {}.type)
+        }.getOrNull() ?: arrayListOf()
+
+        tasks.forEach {
+            runCatching {
+                if (it != null && isStoredTaskUsable(it)) this.add(it)
+            }
+        }
+    }
+
+    private fun isStoredTaskUsable(task: Task): Boolean {
+        return runCatching {
+            task.title.length
+            true
+        }.getOrDefault(false)
     }
 
     override fun check() {

--- a/app/src/main/java/com/pocket_plan/j7_003/data/todolist/TodoList.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/data/todolist/TodoList.kt
@@ -103,7 +103,7 @@ class TodoList: ArrayList<Task>(), Checkable{
     }
 
     private fun fetchFromFile() {
-        val jsonString = StorageHandler.files[StorageId.TASKS]?.readText()
+        val jsonString = StorageHandler.readJsonFromFile(StorageHandler.files[StorageId.TASKS])
 
         this.addAll(
             GsonBuilder().create().fromJson(

--- a/app/src/main/java/com/pocket_plan/j7_003/system_interaction/handler/share/ImportHandler.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/system_interaction/handler/share/ImportHandler.kt
@@ -63,12 +63,12 @@ class ImportHandler(private val parentActivity: Activity) {
         val oldFile = File("${fileDir}old_${id.s}")
 
         // copies the current modules file content to the rollback file
-        oldFile.writeText(StorageHandler.files[id]!!.readText())
+        oldFile.writeText(StorageHandler.readJsonFromFile(StorageHandler.files[id]) ?: "")
         // overwrites the content of the modules file with the selected files content
-        StorageHandler.files[id]!!.writeText(file.readText())
+        StorageHandler.writeTextToFile(StorageHandler.files[id], file.readText())
 
         if (!testFiles()) { // rollbacks the file if the file couldn't be read correctly
-            StorageHandler.files[id]!!.writeText(oldFile.readText())
+            StorageHandler.writeTextToFile(StorageHandler.files[id], oldFile.readText())
         }
 
         // deletes the rollback file
@@ -145,13 +145,16 @@ class ImportHandler(private val parentActivity: Activity) {
 
         // the new files are used to overwrite their corresponding module files
         newFiles.forEach { (id, file) ->
-            StorageHandler.files[id]?.writeText(file.readText())
+            StorageHandler.writeTextToFile(StorageHandler.files[id], file.readText())
         }
 
         // test of all file, if it fails all files are rolled back
         if (!testFiles()) {
             File("${parentActivity.filesDir}/old/").listFiles()!!.forEach { currentFile ->
-                File("${parentActivity.filesDir}/${currentFile.name}").writeText(currentFile.readText())
+                StorageHandler.writeTextToFile(
+                    File("${parentActivity.filesDir}/${currentFile.name}"),
+                    currentFile.readText()
+                )
             }
         }
 

--- a/app/src/main/java/com/pocket_plan/j7_003/system_interaction/handler/share/ImportHandler.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/system_interaction/handler/share/ImportHandler.kt
@@ -191,7 +191,11 @@ class ImportHandler(private val parentActivity: Activity) {
         return try {
             ShoppingListWrapper().check()
             BirthdayList(parentActivity.resources.getStringArray(R.array.months)).check()
-            NoteDirList().check()
+            val noteDirList = NoteDirList()
+            if (!noteDirList.loadedFromStorage) {
+                throw IllegalStateException("Notes JSON could not be loaded")
+            }
+            noteDirList.check()
 
             TodoList().check()
 

--- a/app/src/main/java/com/pocket_plan/j7_003/system_interaction/handler/share/ImportHandler.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/system_interaction/handler/share/ImportHandler.kt
@@ -17,7 +17,6 @@ import com.pocket_plan.j7_003.system_interaction.handler.storage.StorageId
 import java.io.File
 import java.io.InputStream
 import java.util.*
-import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
 
 /**
@@ -63,7 +62,12 @@ class ImportHandler(private val parentActivity: Activity) {
         val oldFile = File("${fileDir}old_${id.s}")
 
         // copies the current modules file content to the rollback file
-        oldFile.writeText(StorageHandler.readJsonFromFile(StorageHandler.files[id]) ?: "")
+        oldFile.writeText(
+            StorageHandler.readJsonFromFile(
+                StorageHandler.files[id],
+                fallbackText = fallbackJson(id)
+            ) ?: fallbackJson(id)
+        )
         // overwrites the content of the modules file with the selected files content
         StorageHandler.writeTextToFile(StorageHandler.files[id], file.readText())
 
@@ -116,6 +120,7 @@ class ImportHandler(private val parentActivity: Activity) {
         // creating the aforementioned directories
         newDir.mkdir()
         oldDir.mkdir()
+        newFiles.clear()
 
         // copy content of each module file to a rollback file in the /old/ directory
         File("${parentActivity.filesDir}/").listFiles()!!.forEach { oldFile ->
@@ -126,25 +131,32 @@ class ImportHandler(private val parentActivity: Activity) {
         }
 
         // unzip all all entries from selected file into the /new/ directory
-        StorageId.values().forEach {
-            //Ignore old (unused) shopping file
-            if (it.s != StorageId.SHOPPING.s) {  // check so only module files are used/transferred
-                // the cache file is created with the corresponding name of the modules file name
-                cacheFile = File("${parentActivity.filesDir}/new/${it.s}")
-
-                // getting the content from the requested zip entry
-                // (only file names from storage ids are valid)
-                entryContent = zipFile.getInputStream(ZipEntry(it.s)).bufferedReader()
-                    .use { reader -> reader.readText() }
-
-                // the read in content is stored in the new file
-                cacheFile.writeText(entryContent)
-                newFiles[it] = cacheFile    // the file is added to a map to be easier managed
+        StorageId.values().forEach { id ->
+            val entry = zipFile.getEntry(id.s)
+            if (entry == null && id == StorageId.SHOPPING) {
+                return@forEach
             }
+
+            // the cache file is created with the corresponding name of the modules file name
+            cacheFile = File("${parentActivity.filesDir}/new/${id.s}")
+
+            // getting the content from the requested zip entry
+            // (only file names from storage ids are valid)
+            entryContent = if (entry != null) {
+                zipFile.getInputStream(entry).bufferedReader()
+                    .use { reader -> reader.readText() }
+            } else {
+                fallbackJson(id)
+            }
+
+            // the read in content is stored in the new file
+            cacheFile.writeText(entryContent)
+            newFiles[id] = cacheFile    // the file is added to a map to be easier managed
         }
 
         // the new files are used to overwrite their corresponding module files
         newFiles.forEach { (id, file) ->
+            StorageHandler.createJsonFile(id, fallbackJson(id))
             StorageHandler.writeTextToFile(StorageHandler.files[id], file.readText())
         }
 
@@ -193,10 +205,17 @@ class ImportHandler(private val parentActivity: Activity) {
             Toast.makeText(parentActivity, parentActivity.getString(R.string.settingsBackupImportSuccessful), Toast.LENGTH_SHORT).show()
 
             true
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             Log.e("IMPORT FAILED", e.toString())
             Toast.makeText(parentActivity, parentActivity.getString(R.string.settingsBackupImportFailed), Toast.LENGTH_SHORT).show()
             false
+        }
+    }
+
+    private fun fallbackJson(id: StorageId): String {
+        return when (id) {
+            StorageId.SETTINGS -> "{}"
+            else -> "[]"
         }
     }
 }

--- a/app/src/main/java/com/pocket_plan/j7_003/system_interaction/handler/storage/StorageHandler.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/system_interaction/handler/storage/StorageHandler.kt
@@ -28,8 +28,8 @@ class StorageHandler {
             writeTextAtomic(file, text)
         }
 
-        fun readJsonFromFile(file: File?): String? {
-            if (file == null) return null
+        fun readJsonFromFile(file: File?, fallbackText: String? = null): String? {
+            if (file == null) return fallbackText
 
             readValidJson(file)?.let { return it }
 
@@ -41,6 +41,14 @@ class StorageHandler {
                 val backupText = readValidJson(backupFile(file, i)) ?: continue
                 writeTextAtomic(file, backupText)
                 return backupText
+            }
+
+            if (fallbackText != null) {
+                if (!isValidJson(fallbackText)) {
+                    throw IllegalArgumentException("Refusing to use invalid fallback JSON")
+                }
+                writeTextToFile(file, fallbackText, rotateBackup = false)
+                return fallbackText
             }
 
             throw IllegalStateException("No readable JSON storage file found for ${file.name}")

--- a/app/src/main/java/com/pocket_plan/j7_003/system_interaction/handler/storage/StorageHandler.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/system_interaction/handler/storage/StorageHandler.kt
@@ -1,15 +1,50 @@
 package com.pocket_plan.j7_003.system_interaction.handler.storage
 
 import com.google.gson.Gson
+import com.google.gson.JsonParser
+import android.util.AtomicFile
 import java.io.File
+import java.io.FileOutputStream
 
 class StorageHandler {
 
     companion object {
+        private const val BACKUP_COUNT = 3
+
         var files = HashMap<StorageId, File>()
         lateinit var path: String
 
-        fun saveAsJsonToFile(file: File?, any: Any) = file?.writeText(Gson().toJson(any))
+        fun saveAsJsonToFile(file: File?, any: Any) {
+            val json = Gson().toJson(any)
+            if (!isValidJson(json)) {
+                throw IllegalArgumentException("Refusing to save invalid JSON")
+            }
+            writeTextToFile(file, json)
+        }
+
+        fun writeTextToFile(file: File?, text: String, rotateBackup: Boolean = true) {
+            if (file == null) return
+            if (rotateBackup) rotateBackups(file)
+            writeTextAtomic(file, text)
+        }
+
+        fun readJsonFromFile(file: File?): String? {
+            if (file == null) return null
+
+            readValidJson(file)?.let { return it }
+
+            if (file.exists()) {
+                preserveCorruptFile(file)
+            }
+
+            for (i in 1..BACKUP_COUNT) {
+                val backupText = readValidJson(backupFile(file, i)) ?: continue
+                writeTextAtomic(file, backupText)
+                return backupText
+            }
+
+            throw IllegalStateException("No readable JSON storage file found for ${file.name}")
+        }
 
         fun createFile(identifier: StorageId, fileName: String) {
             files[identifier] =
@@ -24,12 +59,86 @@ class StorageHandler {
             files[identifier] = setStorageLocation(identifier.s)
 
             if (files[identifier]?.exists() == null || files[identifier]?.exists() == false) {
-                files[identifier]?.writeText(text)
+                writeTextToFile(files[identifier], text, rotateBackup = false)
             }
         }
 
         private fun setStorageLocation(fileName: String): File =
             File(path, fileName)
+
+        private fun rotateBackups(file: File) {
+            if (!file.exists()) return
+
+            val currentText = try {
+                file.readText()
+            } catch (_: Exception) {
+                return
+            }
+
+            if (!isValidJson(currentText)) {
+                preserveCorruptFile(file)
+                return
+            }
+
+            for (i in BACKUP_COUNT downTo 2) {
+                val previous = backupFile(file, i - 1)
+                if (previous.exists()) {
+                    writeTextAtomic(backupFile(file, i), previous.readText())
+                }
+            }
+            writeTextAtomic(backupFile(file, 1), currentText)
+        }
+
+        private fun readValidJson(file: File): String? {
+            if (!file.exists()) return null
+            val text = try {
+                file.readText()
+            } catch (_: Exception) {
+                return null
+            }
+            return if (isValidJson(text)) text else null
+        }
+
+        private fun isValidJson(text: String): Boolean {
+            if (text.isBlank()) return false
+            return try {
+                JsonParser.parseString(text)
+                true
+            } catch (_: Exception) {
+                false
+            }
+        }
+
+        private fun preserveCorruptFile(file: File) {
+            if (!file.exists()) return
+            val corruptText = try {
+                file.readText()
+            } catch (_: Exception) {
+                return
+            }
+            val corruptFile = File(file.parentFile, "${file.name}.corrupt")
+            if (!corruptFile.exists()) {
+                writeTextAtomic(corruptFile, corruptText)
+            }
+        }
+
+        private fun backupFile(file: File, index: Int): File =
+            File(file.parentFile, "${file.name}.bak$index")
+
+        private fun writeTextAtomic(file: File, text: String) {
+            val atomicFile = AtomicFile(file)
+            var stream: FileOutputStream? = null
+            try {
+                val outputStream = atomicFile.startWrite()
+                stream = outputStream
+                outputStream.write(text.toByteArray(Charsets.UTF_8))
+                atomicFile.finishWrite(outputStream)
+                stream = null
+            } catch (e: Exception) {
+                stream?.let { atomicFile.failWrite(it) }
+                throw e
+            }
+        }
 
     }
 }

--- a/app/src/main/java/com/pocket_plan/j7_003/system_interaction/receiver/NotificationReceiver.kt
+++ b/app/src/main/java/com/pocket_plan/j7_003/system_interaction/receiver/NotificationReceiver.kt
@@ -13,6 +13,7 @@ import com.pocket_plan.j7_003.data.settings.SettingsManager
 import com.pocket_plan.j7_003.system_interaction.handler.notifications.AlarmHandler
 import com.pocket_plan.j7_003.system_interaction.handler.notifications.NotificationHandler
 import com.pocket_plan.j7_003.system_interaction.handler.storage.StorageHandler
+import org.threeten.bp.DayOfWeek
 import org.threeten.bp.LocalDate
 
 
@@ -25,21 +26,23 @@ class NotificationReceiver : BroadcastReceiver() {
         AndroidThreeTen.init(this.context)
         StorageHandler.path = context.filesDir.absolutePath
         this.localDate = LocalDate.now()
+        SettingsManager.init()
 
         when (intent.extras?.get("Notification")) {
             "Birthday" -> birthdayNotifications()
             "SReminder" -> checkSleepNotification(intent)
         }
 
-        SettingsManager.init()
         val time = SettingsManager.getSetting(SettingId.BIRTHDAY_NOTIFICATION_TIME) as String
         AlarmHandler.setBirthdayAlarms(time, context = context)
     }
 
     private fun checkSleepNotification(intent: Intent) {
-        SleepReminder(context).reminder[intent.extras?.get("weekday")]?.updateAlarm(
-            intent.extras?.getInt("requestCode")!!
-        )
+        val weekday = intent.extras?.getString("weekday") ?: return
+        val dayOfWeek = runCatching { DayOfWeek.valueOf(weekday) }.getOrNull() ?: return
+        val requestCode = intent.extras?.getInt("requestCode") ?: return
+
+        SleepReminder(context).reminder[dayOfWeek]?.updateAlarm(requestCode)
         sRNotification()
     }
 


### PR DESCRIPTION
## Summary

This PR hardens PocketPlan local storage layer and fixes several data-loss/crash edge cases around notes, shopping lists, imports, and reminders.

## Storage reliability

- Write JSON files atomically using Android AtomicFile so interrupted writes do not leave half-written JSON behind.
- Keep rolling JSON backups (.bak1-.bak3) before overwriting valid storage files.
- Preserve unreadable/corrupt originals as .corrupt instead of immediately replacing them.
- Restore from the newest valid backup when the primary JSON file is missing or corrupt.
- Add safe fallback defaults for non-notes storage files so a corrupted settings, sleep, birthday, todo, shopping, or user-template file does not lock users out of the app.
- Make backup imports tolerate older/missing JSON files while still validating imported data.

## Notes

- Add stable note IDs and use ID-based matching for restore/edit flows.
- Fix cases where closing the app while editing could restore the wrong note, duplicate a note, or lose an unsaved edit.
- Preserve corrupt notes storage instead of silently replacing it with an empty notes tree.
- Make import validation reject notes JSON that failed to actually load.

## Shopping lists

- Normalize unknown/legacy shopping category tags into the default category instead of crashing.
- Guard shopping category lookup paths against invalid category codes.
- Fix legacy shopping-list migration so migrated data is not double-loaded.
- Add defensive parsing for shopping lists and custom shopping item templates.

## Reminders and other storage-backed lists

- Repair partial or malformed sleep reminder maps by recreating missing/invalid weekdays.
- Fix sleep notification rescheduling by converting stored weekday strings back to DayOfWeek.
- Add defensive loading for birthday and todo records so malformed entries are skipped instead of crashing startup.

## Version

- Bump version to 1.5 / 55.